### PR TITLE
2021/04/11 renewal 

### DIFF
--- a/src/main/java/info/shibafu528/shindan4j/ListMode.java
+++ b/src/main/java/info/shibafu528/shindan4j/ListMode.java
@@ -7,22 +7,23 @@ import java.net.URLEncoder;
  * Created by shibafu on 14/06/15.
  */
 public enum ListMode {
-    NEW("0"),
-    BEST("1"),
+    NEW("latest"),
+    BEST("overall"),
     HOT,
     PICKUP,
     DAILY,
     MONTHLY,
-    FAVORITE("fav"),
+    FAVORITE("favorite"),
     FAVORITE_HOT("favhot"),
     PICTURE("pic"),
     MOVIE("mov"),
+    CHART,
     SEARCH,
-    THEME("tag");
+    THEME("themes");
 
-    private static final String LISTPAGE_URL = "https://shindanmaker.com/c/list?";
+    private static final String LISTPAGE_URL = "https://shindanmaker.com/list/";
 
-    private String value;
+    private final String value;
 
     private ListMode() {
         this.value = name().toLowerCase();
@@ -39,9 +40,8 @@ public enum ListMode {
 
     public String toUrlString(int page, String... queries) throws UnsupportedEncodingException {
         StringBuilder sb = new StringBuilder(LISTPAGE_URL);
-        sb.append("mode=");
         sb.append(toString());
-        sb.append("&p=");
+        sb.append("?p=");
         sb.append(page);
         String key = null;
         for (String query : queries) {

--- a/src/main/java/info/shibafu528/shindan4j/ShindanPage.java
+++ b/src/main/java/info/shibafu528/shindan4j/ShindanPage.java
@@ -1,18 +1,20 @@
 package info.shibafu528.shindan4j;
 
+import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by shibafu on 14/06/15.
  */
 class ShindanPage extends Summary{
 
-    private String postUrl;
+    private final String postUrl;
 
     ShindanPage(int pageId, String title, String description, String authorName,
                 String hashTag, List<String> themes,
@@ -23,21 +25,24 @@ class ShindanPage extends Summary{
 
     @Override
     public ShindanResult shindan(String name) throws IOException {
+        Session session = beginSession();
         Document doc = Jsoup.connect(postUrl)
                 .userAgent(ShindanMaker.getUserAgent())
                 .timeout(ShindanMaker.getTimeout())
-                .data("u", name)
+                .cookies(session.cookies)
+                .data("_token", session.token)
+                .data("name", name)
                 .post();
         //結果を取得
-        Element fullElem = doc.select("textarea#copy_text").first();
-        Element shareElem = doc.select("textarea#copy_text_140").first();
+        Element fullElem = doc.select("textarea#copy-textarea-all").first();
+        Element shareElem = doc.select("textarea#copy-textarea-140").first();
         if (shareElem == null) {
-            throw new IOException("textarea#copy_text_140 がHTML上に見つかりません\nURL:" + getPageUrl());
+            throw new IOException("textarea#copy-textarea-140 がHTML上に見つかりません\nURL:" + getPageUrl());
         }
         //フルの診断結果が格納されている要素を判定
         Element longestResultElem;
-        if (fullElem == null) {
-            //全文コピペ用textareaがない場合、通常のコピペ用textareaを使う
+        if (fullElem == null || fullElem.text().trim().equals("")) {
+            //全文コピペ用textareaがないか空の場合、通常のコピペ用textareaを使う
             longestResultElem = shareElem;
         } else {
             longestResultElem = fullElem;
@@ -53,5 +58,31 @@ class ShindanPage extends Summary{
                 getAccessCount(), getFavoritedCount(), getResultPatterns(),
                 isHot()? "HOT":"",
                 isPickup()? "PICKUP":"");
+    }
+
+    private Session beginSession() throws IOException {
+        Connection.Response res = Jsoup.connect(postUrl)
+                .userAgent(ShindanMaker.getUserAgent())
+                .timeout(ShindanMaker.getTimeout())
+                .method(Connection.Method.GET)
+                .execute();
+        Document doc = res.parse();
+
+        String token = "";
+        Element tokenElement = doc.select("#shindanForm input[name=_token]").first();
+        if (tokenElement != null) {
+            token = tokenElement.attr("value").trim();
+        }
+        return new Session(res.cookies(), token);
+    }
+
+    private static class Session {
+        public final Map<String, String> cookies;
+        public final String token;
+
+        public Session(Map<String, String> cookies, String token) {
+            this.cookies = cookies;
+            this.token = token;
+        }
     }
 }


### PR DESCRIPTION
2021/4/11のサイトリニューアル対応。

## やった
* 診断取得のセレクタ修正 
* 診断実行のシーケンスとリクエストパラメータ修正
  * Session IDとCSRF Tokenが必要
* 診断リスト取得とテーマ検索のリクエストURLおよびセレクタ修正

## やってない
* フリーワード検索画面への対応
  * サイト側で未実装、503が返ってくる。
* リスト系画面のページネーション
  * Ajax化された時からずっと壊れてたし、今回も一旦やらない